### PR TITLE
Use const fn over const generics, lowering MSRV to 1.47

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: 1.51.0, os: ubuntu-latest }
+          - { rust: 1.47.0, os: ubuntu-latest }
           - { rust: stable, os: ubuntu-latest }
           - { rust: stable, os: macos-latest }
           - { rust: stable, os: windows-latest }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://github.com/thomcc/nonzero_lit/workflows/CI/badge.svg)](https://github.com/thomcc/nonzero_lit/actions)
 [![Docs](https://docs.rs/nonzero_lit/badge.svg)](https://docs.rs/nonzero_lit)
 [![Latest Version](https://img.shields.io/crates/v/nonzero_lit.svg)](https://crates.io/crates/nonzero_lit)
-![Minimum Rust Version](https://img.shields.io/badge/MSRV%201.51-blue.svg)
+![Minimum Rust Version](https://img.shields.io/badge/MSRV%201.47-blue.svg)
 
 A small macro crate providing safe, easy, and fully zero-cost way to construct constant or literal instances of the `NonZero*` types from `core::num`.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ macro_rules! usize {
         const __E: usize = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroUsize = $crate::_private::nz_usize::<__E>();
+            const NZ: $crate::_private::NonZeroUsize = $crate::_private::nz_usize(__E);
             NZ
         }
     }};
@@ -219,7 +219,7 @@ macro_rules! isize {
         const __E: isize = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroIsize = $crate::_private::nz_isize::<__E>();
+            const NZ: $crate::_private::NonZeroIsize = $crate::_private::nz_isize(__E);
             NZ
         }
     }};
@@ -266,7 +266,7 @@ macro_rules! u8 {
         const __E: u8 = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroU8 = $crate::_private::nz_u8::<__E>();
+            const NZ: $crate::_private::NonZeroU8 = $crate::_private::nz_u8(__E);
             NZ
         }
     }};
@@ -313,7 +313,7 @@ macro_rules! i8 {
         const __E: i8 = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroI8 = $crate::_private::nz_i8::<__E>();
+            const NZ: $crate::_private::NonZeroI8 = $crate::_private::nz_i8(__E);
             NZ
         }
     }};
@@ -360,7 +360,7 @@ macro_rules! u16 {
         const __E: u16 = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroU16 = $crate::_private::nz_u16::<__E>();
+            const NZ: $crate::_private::NonZeroU16 = $crate::_private::nz_u16(__E);
             NZ
         }
     }};
@@ -407,7 +407,7 @@ macro_rules! i16 {
         const __E: i16 = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroI16 = $crate::_private::nz_i16::<__E>();
+            const NZ: $crate::_private::NonZeroI16 = $crate::_private::nz_i16(__E);
             NZ
         }
     }};
@@ -454,7 +454,7 @@ macro_rules! u32 {
         const __E: u32 = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroU32 = $crate::_private::nz_u32::<__E>();
+            const NZ: $crate::_private::NonZeroU32 = $crate::_private::nz_u32(__E);
             NZ
         }
     }};
@@ -501,7 +501,7 @@ macro_rules! i32 {
         const __E: i32 = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroI32 = $crate::_private::nz_i32::<__E>();
+            const NZ: $crate::_private::NonZeroI32 = $crate::_private::nz_i32(__E);
             NZ
         }
     }};
@@ -548,7 +548,7 @@ macro_rules! u64 {
         const __E: u64 = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroU64 = $crate::_private::nz_u64::<__E>();
+            const NZ: $crate::_private::NonZeroU64 = $crate::_private::nz_u64(__E);
             NZ
         }
     }};
@@ -595,7 +595,7 @@ macro_rules! i64 {
         const __E: i64 = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroI64 = $crate::_private::nz_i64::<__E>();
+            const NZ: $crate::_private::NonZeroI64 = $crate::_private::nz_i64(__E);
             NZ
         }
     }};
@@ -642,7 +642,7 @@ macro_rules! u128 {
         const __E: u128 = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroU128 = $crate::_private::nz_u128::<__E>();
+            const NZ: $crate::_private::NonZeroU128 = $crate::_private::nz_u128(__E);
             NZ
         }
     }};
@@ -689,7 +689,7 @@ macro_rules! i128 {
         const __E: i128 = $val;
         {
             #[deny(const_err)]
-            const NZ: $crate::_private::NonZeroI128 = $crate::_private::nz_i128::<__E>();
+            const NZ: $crate::_private::NonZeroI128 = $crate::_private::nz_i128(__E);
             NZ
         }
     }};
@@ -704,13 +704,13 @@ pub mod _private {
     };
 
     macro_rules! define_nz_ctor {
-        ($(pub fn $nz_func:ident <const N: $int:ident>() -> $NonZeroInt:ident;)+) => {$(
+        ($(pub fn $nz_func:ident($n:ident : $int:ident) -> $NonZeroInt:ident;)+) => {$(
             #[inline]
-            pub const fn $nz_func<const N: $int>() -> $NonZeroInt {
+            pub const fn $nz_func($n : $int) -> $NonZeroInt {
                 // Note: Hacky const fn assert.
-                let _ = ["N must not be zero"][(N == 0) as usize];
+                let _ = ["N must not be zero"][($n == 0) as usize];
 
-                match $NonZeroInt::new(N) {
+                match $NonZeroInt::new($n) {
                     Some(x) => x,
                     // The assert above makes this branch unreachable
                     None => loop {},
@@ -720,17 +720,17 @@ pub mod _private {
     }
 
     define_nz_ctor! {
-        pub fn nz_usize<const N: usize>() -> NonZeroUsize;
-        pub fn nz_isize<const N: isize>() -> NonZeroIsize;
-        pub fn nz_u8<const N: u8>() -> NonZeroU8;
-        pub fn nz_i8<const N: i8>() -> NonZeroI8;
-        pub fn nz_u16<const N: u16>() -> NonZeroU16;
-        pub fn nz_i16<const N: i16>() -> NonZeroI16;
-        pub fn nz_u32<const N: u32>() -> NonZeroU32;
-        pub fn nz_i32<const N: i32>() -> NonZeroI32;
-        pub fn nz_u64<const N: u64>() -> NonZeroU64;
-        pub fn nz_i64<const N: i64>() -> NonZeroI64;
-        pub fn nz_u128<const N: u128>() -> NonZeroU128;
-        pub fn nz_i128<const N: i128>() -> NonZeroI128;
+        pub fn nz_usize(n: usize) -> NonZeroUsize;
+        pub fn nz_isize(n: isize) -> NonZeroIsize;
+        pub fn nz_u8(n: u8) -> NonZeroU8;
+        pub fn nz_i8(n: i8) -> NonZeroI8;
+        pub fn nz_u16(n: u16) -> NonZeroU16;
+        pub fn nz_i16(n: i16) -> NonZeroI16;
+        pub fn nz_u32(n: u32) -> NonZeroU32;
+        pub fn nz_i32(n: i32) -> NonZeroI32;
+        pub fn nz_u64(n: u64) -> NonZeroU64;
+        pub fn nz_i64(n: i64) -> NonZeroI64;
+        pub fn nz_u128(n: u128) -> NonZeroU128;
+        pub fn nz_i128(n: i128) -> NonZeroI128;
     }
 }


### PR DESCRIPTION
In theory the `unsafe` version (removed by #2) supports MSRV back to 1.36... Unfortunately, that version fails to detect creating a zero nonzero at compile time, since handling panic in const fn wasn't handled that way back then.

So, 1.47 it is. Would have been kinda nice to get debian stable (1.41) but... honestly who cares.